### PR TITLE
Add themes to settings

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,8 +24,6 @@ var onOffstates = [];
 var gettingDevices = false;
 var md;
 var _GRAPHS_LOADED = {};
-var _BACKGROUND_IMAGE = 'img/bg2.jpg';
-var _THEME = 'default';
 var _STREAMPLAYER_TRACKS = {"track": 1, "name": "Music FM", "file": "http://stream.musicfm.hu:8000/musicfm.mp3"};
 var _THOUSAND_SEPARATOR = '.';
 var _DECIMAL_POINT = ',';
@@ -35,17 +33,7 @@ function loadFiles() {
         if (objectlength(columns) === 0) defaultcolumns = true;
 
         _GRAPHREFRESH = 5;
-        if (typeof(screens) === 'undefined' || objectlength(screens) === 0) {
-            screens = {};
-            screens[1] = {};
-            screens[1]['background'] = _BACKGROUND_IMAGE;
-            screens[1]['columns'] = [];
-            if (defaultcolumns === false) {
-                for (c in columns) {
-                    if (c !== 'bar') screens[1]['columns'].push(c);
-                }
-            }
-        }
+        
         //Check language before loading settings and fallback to English when not set
         if (typeof(localStorage.dashticz_language) !== 'undefined') {
             setLang = localStorage.dashticz_language
@@ -64,12 +52,22 @@ function loadFiles() {
 
         $.ajax({url: 'js/settings.js', async: false, dataType: 'script'}).done(function () {
             loadSettings();
-
+	    if (typeof(screens) === 'undefined' || objectlength(screens) === 0) {
+		screens = {};
+		screens[1] = {};
+		screens[1]['background'] = settings['background_image'];
+		screens[1]['columns'] = [];
+		if (defaultcolumns === false) {
+			for (c in columns) {
+			if (c !== 'bar') screens[1]['columns'].push(c);
+			}
+		}
+	    }
             $('<link href="css/creative.css?v=' + cache + '" rel="stylesheet">').appendTo('head');
             $('<link href="vendor/weather/css/weather-icons.min.css?v=' + cache + '" rel="stylesheet">').appendTo('head');
 
-            if (_THEME !== 'default') {
-                $('<link rel="stylesheet" type="text/css" href="themes/' + _THEME + '/' + _THEME + '.css?v=' + cache + '" />').appendTo('head');
+            if (settings['theme'] !== 'default') {
+              $('<link rel="stylesheet" type="text/css" href="themes/' + settings['theme'] + '/' + settings['theme'] + '.css?v=' + cache + '" />').appendTo('head');
             }
             $('<link href="' + customfolder + '/custom.css?v=' + cache + '" rel="stylesheet">').appendTo('head');
 

--- a/js/main.js
+++ b/js/main.js
@@ -277,6 +277,9 @@ function buildScreens() {
             for (s in screens[t]) {
                 if (s !== 'maxwidth' && s !== 'maxheight') {
                     var screenhtml = '<div class="screen screen' + s + ' swiper-slide slide' + s + '"';
+		    if (typeof(screens[t][s]['background']) === 'undefined') {
+			screens[t][s]['background'] = settings['background_image'];
+		    }
                     if (typeof(screens[t][s]['background']) !== 'undefined') {
                         if (screens[t][s]['background'].indexOf("/") > 0) screenhtml += 'style="background-image:url(\'' + screens[t][s]['background'] + '\');"';
                         else screenhtml += 'style="background-image:url(\'img/' + screens[t][s]['background'] + '\');"';

--- a/js/settings.js
+++ b/js/settings.js
@@ -68,6 +68,16 @@ settingList['screen']['hide_topbar'] = {};
 settingList['screen']['hide_topbar']['title'] = language.settings.screen.hide_topbar;
 settingList['screen']['hide_topbar']['type'] = 'checkbox';
 
+settingList['screen']['theme'] = {};
+settingList['screen']['theme']['title'] = language.settings.screen.dashticz_themes;
+settingList['screen']['theme']['type'] = 'text';
+settingList['screen']['theme']['help'] = language.settings.screen.dashticz_themes_help;
+
+settingList['screen']['background_image'] = {};
+settingList['screen']['background_image']['title'] = language.settings.screen.background_image;
+settingList['screen']['background_image']['type'] = 'text';
+settingList['screen']['background_image']['help'] = language.settings.screen.background_image.help;
+
 settingList['screen']['standby_after'] = {};
 settingList['screen']['standby_after']['title'] = language.settings.screen.standby_after;
 settingList['screen']['standby_after']['type'] = 'text';
@@ -481,6 +491,8 @@ if (typeof(settings['garbage_use_cors_prefix']) === 'undefined') settings['garba
 if (typeof(settings['lineColors']) === 'undefined') settings['lineColors'] = ['#eee', '#eee', '#eee'];
 if (typeof(settings['room_plan']) === 'undefined') settings['room_plan'] = 0;
 if (typeof(settings['garbage_use_cors_prefix']) === 'undefined') settings['garbage_use_cors_prefix'] = 1;
+if (typeof(settings['theme']) === 'undefined') settings['theme'] = 'default';
+if (typeof(settings['background_image']) === 'undefined') settings['background_image'] = 'img/bg2.jpg';
 
 var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';


### PR DESCRIPTION
Benefits to use themes is that you can use same theme on all devices with diffrent switches or the other way around, same switches with diffrent themes.
The themes css will be override by the custom.css.
You can change the background image in settings but you can still change that as before CONFIG.js and will be override by var screens = {}.
If you not define background image in var screen = {} it uses config['background_image'] instead.

@robgeerts Add language strings:
"dashticz_themes":"Dashticz Theme"
"dashticz_themes_help":"Set the name of the theme (eg. white) the theme will be overide by custom.css"
"background_image":"Background Image"
"background_image_help":"Set path to background image eg. img/bg2.jpg or http://yourimage.com/image.jpg"