### PR TITLE
Added update checker

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -420,6 +420,17 @@ a.playlist {
 }
 /* Thermostat CSS: */
 
+.update {
+	background: rgba(0,0,0,0.6);
+	border-radius: 0px;
+	color: #fff;
+	bottom:0;
+	font-weight:bold;
+	right:0;
+	padding:10px;
+	position:absolute;
+	z-index:9999;
+}
 .editmode {
 	color:white;
 	background-color:red;

--- a/js/main.js
+++ b/js/main.js
@@ -52,6 +52,7 @@ function loadFiles() {
             }
         });
 
+	$.ajax({url: 'js/version.js', async: false, dataType: 'script'});
         $.ajax({url: 'js/settings.js', async: false, dataType: 'script'}).done(function () {
             loadSettings();
 	    usrEnc = window.btoa(settings['user_name']);

--- a/js/settings.js
+++ b/js/settings.js
@@ -413,7 +413,7 @@ settingList['about'] = {};
 settingList['about']['title'] = language.settings.about.title;
 
 settingList['about']['about_text'] = {};
-settingList['about']['about_text']['title'] = 'Dashticz V2.0 by Rob Geerts';
+settingList['about']['about_text']['title'] = 'Dashticz ' + dashticz_version + ' ' + dashticz_branch + ' by Rob Geerts<br>' + newVersion;
 
 settingList['about']['about_text2'] = {};
 settingList['about']['about_text2']['title'] = 'Years after developing the old and original Dashticz, I decided to start over.<br><br>For more help visit: <a href="http://www.domoticz.com/wiki/Dashticz_V2" target="_blank">http://www.domoticz.com/wiki/Dashticz_V2</a><br>You can also check out our helpful <a href="https://www.domoticz.com/forum/viewforum.php?f=67" target="_blank">community</a> in Dashticz topic on the Domoticz forum.';

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,31 @@
+
+	/*
+	Check the SECOND latest commit on github because the latest commit is updating ref_commit in this file.
+	Next this file is reading comments from the latest commit (update ref_commit) eg. "New function - Update checker"
+	*/
+	
+var dashticz_version = 'V2.0';
+var dashticz_branch = 'beta'; /* master or beta */
+var ref_commit = '077fc5c5861b7f66ac68a7a8ef18abb5502c84e2' /* Reference commit - add the latest commit BEFORE make a PR of this file */
+var newVersion = '';
+var moved = false;
+	
+$.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + dashticz_branch, async: false, dataType: 'json', success: function(data) {
+	
+	dashticz_branch = data['name']
+	var message = 'Last change made: ' + data['commit']['commit']['message'];
+	
+	if (ref_commit !== data['commit']['parents'][0]['sha']) {
+		moved = true;
+		newVersion = '<br><i>New Version is available! <a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a></i><br><i>' + message + '</i>';
+	}
+	else if (ref_commit === data['commit']['parents'][0]['sha']) {
+		moved = false;
+		newVersion = '<br><i>You are running latest version.</i>';
+	}
+}
+});
+
+if (moved == true) {
+        $('body').append('<div class="update">New Version is available!&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a>&nbsp;&nbsp;</div>');
+    }

--- a/js/version.js
+++ b/js/version.js
@@ -17,7 +17,7 @@ $.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + das
 	
 	if (ref_commit !== data['commit']['parents'][0]['sha']) {
 		moved = true;
-		newVersion = '<br><i>New Version is available! <a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a></i><br><i>' + message + '</i>';
+		newVersion = '<br><i>New version is available! <a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a></i><br><i>' + message + '</i>';
 	}
 	else if (ref_commit === data['commit']['parents'][0]['sha']) {
 		moved = false;
@@ -27,5 +27,5 @@ $.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + das
 });
 
 if (moved == true) {
-        $('body').append('<div class="update">New Version is available!&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a>&nbsp;&nbsp;</div>');
+        $('body').append('<div class="update">New version is available!&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">Click here to download</a>&nbsp;&nbsp;</div>');
     }


### PR DESCRIPTION
Check the SECOND latest commit on github because the latest commit is updating ref_commit in version.js. Next, version.js is reading comments from the latest commit (update ref_commit) eg. "New function - Update checker.

`var ref_commit = '077fc5c5861b7f66ac68a7a8ef18abb5502c84e2' /* Reference commit - Change this to the latest commit BEFORE make a PR of version.js */`

![dashticz_update](https://user-images.githubusercontent.com/28799807/35977518-9e7be92c-0ce3-11e8-8fc7-ce6797a200a5.jpg)

![dashticz_update 2](https://user-images.githubusercontent.com/28799807/35977525-a550b12e-0ce3-11e8-8c40-5302640ec7c2.jpg)
