### PR TITLE
Fixes new Domoticz behaviour preventing XSS.

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -4,7 +4,7 @@
 	width:100%;
 	height:100%;
 	background-color:#000;
-	z-index:9999;
+	z-index:99999;
 	text-align:center;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -969,9 +969,9 @@ function getDevices(override) {
         if (typeof(req) !== 'undefined') req.abort();
         gettingDevices = true;
 
-        req = $.getJSONP({
-            url: settings['domoticz_ip'] + '/json.htm?username=' + usrEnc + '&password=' + pwdEnc + '&type=devices&plan=' + settings['room_plan'] + '&filter=all&used=true&order=Name&jsoncallback=?',
-            type: 'GET', async: true, contentType: "application/json", dataType: 'jsonp',
+        req = $.get({
+            url: settings['domoticz_ip'] + '/json.htm?username=' + usrEnc + '&password=' + pwdEnc + '&type=devices&plan=' + settings['room_plan'] + '&filter=all&used=true&order=Name',
+            type: 'GET', async: true, contentType: "application/json",
             error: function (jqXHR, textStatus) {
                 console.error("Domoticz error!\nPlease, double check the path to Domoticz in Settings!");
             },


### PR DESCRIPTION
In the latest release a part of domoticz/domoticz#2105 was included. The
inclusion only consisted of the XSS fixes that were proposed by
@Jarthianur. While helpful, this broke Dashticz (beta) because of the
JSONP request to Domoticz.

Since the internal Domoticz webserver provides CORS to all origins, it
shouldn't be an issue to just use a regular JSON request instead of a
JSONP one.

I've tested this locally to both HTTP and HTTPS origins and seems to be
working. A second opinion on this should be great though. Also I've
amneded the CSS with a bit higher Z-value to prevent showing thermostat
buttons while the preload is displayed.