### PR TITLE
Fixed typo for spotify changedevice function

### DIFF
--- a/js/spotify.js
+++ b/js/spotify.js
@@ -109,7 +109,7 @@ function getSpotifyData(columndiv,rand){
 	});
 }
 function changeDevice(){
-	getCurrentHTML(currentPlaying, 'changdevice');
+	getCurrentHTML(currentPlaying, 'changedevice');
 }
 function getCurrentHTML(item, typeAction){
 	if(typeof typeAction === 'undefined') typeAction = false;


### PR DESCRIPTION
There was a typo in the changedevice function of the spotify plugin which prevented the currently playing item to load.