### PR TITLE
Fixed spotify blocking loading of devices

### DIFF
--- a/js/spotify.js
+++ b/js/spotify.js
@@ -42,7 +42,7 @@ function getSpotifyData(columndiv,rand){
 	currentPlaying=false;
 	getUserData()
 	.then(function(userdata) {
-		getDevices()
+		getSpotifyDevices()
 		.then(function(devices) {
 			if(typeof(devices['devices'])!=='undefined'){
 				devices = devices['devices'];
@@ -251,7 +251,7 @@ function getTracks(url) {
 		}
 	});
 }
-function getDevices() {
+function getSpotifyDevices() {
 	return $.ajax({
 		url: 'https://api.spotify.com/v1/me/player/devices',
 		headers: {


### PR DESCRIPTION
Quickfix for the bug where the devices didn't load when the spotify block was included. Better solution would be to make each js-plugin a js-module and dont expose the private members to the global scope.