### PR TITLE
fix for checkbox settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -533,6 +533,15 @@ if (typeof(settings['theme']) === 'undefined') settings['theme'] = 'default';
 if (typeof(settings['background_image']) === 'undefined') settings['background_image'] = 'img/bg2.jpg';
 if (typeof(settings['loginEnabled']) === 'undefined') settings['loginEnabled'] = 0;
 
+//The Config settings for all checkbox items will be converted to a number
+for (const s in settingList){
+  for (const t in settingList[s]) {
+    if(typeof(settingList[s][t].type)!=='undefined' && settingList[s][t].type==='checkbox') {
+      settings[t]=Number(settings[t]);
+    }
+  }
+}
+
 var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';
 


### PR DESCRIPTION
Several settings in config.js with value '0' were interpreted as text, meaning not 0. With other words: '0' was interpreted as true. This resulted in unexpected behavior.

With this fix all settings with type 'checkbox' will be interpreted correctly, with or without enclosing quotes.

This also addresses the issue described in #310. The 0-values still are written to file with single quotes, but they are interpreted correctly by dashticz.
