### PR TITLE
Save settings: Fix for writing text settings starting with a number.

### DIFF
--- a/js/savesettings.php
+++ b/js/savesettings.php
@@ -10,8 +10,9 @@ foreach($rows as $r => $row){
 
 $newconf="var config = {}\n";
 foreach($_POST as $n => $v){
-	if(intval($v)==1) $newconf.= "config['".$n."'] = ".$v.";\n";
-	else $newconf.= "config['".$n."'] = '".$v."';\n";
+//	if(intval($v)==1) $newconf.= "config['".$n."'] = ".$v.";\n";
+//	else $newconf.= "config['".$n."'] = '".$v."';\n";
+	$newconf.="config['".$n."'] = ".$v.";\n";
 }
 $config=file_put_contents('../custom/CONFIG.js',$before.$newconf.implode("\n",$rows));
 exit();

--- a/js/settings.js
+++ b/js/settings.js
@@ -640,7 +640,7 @@ function saveSettings() {
         }
 
         else alertSettings += "config['" + $(this).attr('name') + "'] = '" + $(this).val() + "';\n";
-        saveSettings[$(this).attr('name')] = $(this).val();
+        saveSettings[$(this).attr('name')] = "'"+$(this).val()+"'";
     });
 
     $('div#settingspopup input[type="checkbox"]').each(function () {


### PR DESCRIPTION
All Text settings are written to CONFIG.js with enclosing quotes. All checkboxes are written as 0 or 1 without quotes.
Solves #310, and some issues reported at Domoticz forum:
https://www.domoticz.com/forum/viewtopic.php?f=67&t=17427&start=400#p182857
