### PR TITLE
Add get domoticz version

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1419,7 +1419,9 @@ function handleDevice(device, idx) {
     }
 
     if (typeof(device['LevelActions']) !== 'undefined' && device['LevelNames'] !== "") {
-        var names =  window.atob(device['LevelNames']).split('|');
+	var names;
+        if (levelNamesEncoded === true) names =  window.atob(device['LevelNames']).split('|');
+	else names = device['LevelNames'].split('|');
 
         html += iconORimage(idx, 'fa-lightbulb-o', buttonimg, getIconStatusClass(device['Status']) + ' icon');
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -425,6 +425,9 @@ settingList['about']['about_text3']['title'] = 'Do you appreciate my work and wa
 settingList['about']['about_text4'] = {};
 settingList['about']['about_text4']['title'] = 'If you have any issues you can report them in our community thread <a href="https://www.domoticz.com/forum/viewtopic.php?f=67&t=17427" target="_blank">Bug report</a>.'
 
+settingList['about']['about_text5'] = {};
+settingList['about']['about_text5']['title'] = domoversion + dzVents + python;
+
 var settings = {};
 doneSettings = false;
 if (typeof(Storage) !== "undefined") {

--- a/js/version.js
+++ b/js/version.js
@@ -9,10 +9,12 @@ var dashticz_branch = 'beta'; /* master or beta */
 var ref_commit = '2dc5f130afad00d852b8427cc8f3bbc7f6eefacb' /* Reference commit - add the latest commit BEFORE make a PR of this file */
 var newVersion = '';
 var moved = false;
+var loginCredentials ='';
 var domoversion = '';
 var dzVents = '';
 var python = '';
-var levelNamesEncodeVersion = '3.9476'
+var levelNamesEncoded = false;
+var levelNamesEncodeVersion = '3.9476' /* Domoticz version above this, level names are encoded */
 	
 $.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + dashticz_branch, async: false, dataType: 'json', success: function(data) {
 	
@@ -34,11 +36,13 @@ if (moved == true) {
 	infoMessage(language.misc.new_version + '!' , '<a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">' + language.misc.download + '</a>');
 }
 
-$.ajax({url: config['domoticz_ip'] + '/json.htm?username=' + window.btoa(config['user_name']) + '&password=' + window.btoa(config['pass_word']) + '&type=command&param=getversion', async: false, dataType: 'json', success: function(data) {
+if(typeof(window.btoa(config['user_name']))!=='undefined' && window.btoa(config['pass_word'])!=='') loginCredentials = 'username=' + window.btoa(config['user_name']) + '&password=' + window.btoa(config['pass_word']) + '&';
+
+$.ajax({url: config['domoticz_ip'] + '/json.htm?' + loginCredentials + 'type=command&param=getversion', async: false, dataType: 'json', success: function(data) {
 	
 	domoversion = 'Domoticz version: ' + data.version;
 	dzVents = '<br>dzVents version: ' + data.dzvents_version;
 	python = '<br> Python version: ' + data.python_version;
-	console.log(data);
+	if (domoticzVersion >= levelNamesEncodeVersion) levelNamesEncoded = true; else levelNamesEncoded = false;
 }
 });

--- a/js/version.js
+++ b/js/version.js
@@ -9,6 +9,10 @@ var dashticz_branch = 'beta'; /* master or beta */
 var ref_commit = '2dc5f130afad00d852b8427cc8f3bbc7f6eefacb' /* Reference commit - add the latest commit BEFORE make a PR of this file */
 var newVersion = '';
 var moved = false;
+var domoversion = '';
+var dzVents = '';
+var python = '';
+var levelNamesEncodeVersion = '3.9476'
 	
 $.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + dashticz_branch, async: false, dataType: 'json', success: function(data) {
 	
@@ -29,3 +33,12 @@ $.ajax({url: 'https://api.github.com/repos/Dashticz/dashticz_v2/branches/' + das
 if (moved == true) {
 	infoMessage(language.misc.new_version + '!' , '<a href="https://github.com/Dashticz/dashticz_v2/tree/' + dashticz_branch + '" target="_blank">' + language.misc.download + '</a>');
 }
+
+$.ajax({url: config['domoticz_ip'] + '/json.htm?username=' + window.btoa(config['user_name']) + '&password=' + window.btoa(config['pass_word']) + '&type=command&param=getversion', async: false, dataType: 'json', success: function(data) {
+	
+	domoversion = 'Domoticz version: ' + data.version;
+	dzVents = '<br>dzVents version: ' + data.dzvents_version;
+	python = '<br> Python version: ' + data.python_version;
+	console.log(data);
+}
+});


### PR DESCRIPTION
This patch checks domoticz version. If version is above 3.9476 then level names will be encoded. Also added Domoticz,  dzVents and python versions in info page. 