### PR TITLE
Improve column width especially for devices with slider

### DIFF
--- a/css/creative.css
+++ b/css/creative.css
@@ -114,8 +114,8 @@
 }
 
 .trashcan {
-    width: 100%;
 	margin-left:-4px;
+	height:30px;
 }
 .modal {
 	z-index:9999;
@@ -546,10 +546,6 @@ a.playlist {
 	}
 }
 @media only screen and (max-width: 1000px) {
-.trashcan {
-	margin-left:0px !important;
-}
-
 	.input-groupBtn .stop {
 		width: 60px;
 		margin-right: -23px;
@@ -588,6 +584,7 @@ a.playlist {
 .lastupdate {
 	font-size: 10px;
     color: #bbb;
+		white-space:nowrap
 }
 .graphpopup {overflow:hidden;}
 html,
@@ -916,10 +913,20 @@ Only add this hover on NON touch devices
 }
 
 .col-icon {
-	width:50px !important;
+	width:40px !important;
 }
+
+.col-data {
+	width: calc(100% - 45px);
+}
+
+.col-no-icon {
+	width: calc(100% - 15px);
+}
+
 .slider {
 	margin-top:7px;
+	margin-right: 7px;
 }
 .weekday {margin-bottom: 5px;}
 .ui-widget.ui-widget-content {
@@ -1040,15 +1047,6 @@ img.icon {
 
 @media (max-width: 1400px) {
 	
-	.col-icon {
-		width:30px !important;
-	}
-	img.icon {
-		max-width:20px !important;
-	}
-	.fa,.wi {
-		font-size:15px !important;
-	}
 	#weather .wi {
 		font-size:24px !important;
 	}
@@ -1090,6 +1088,14 @@ img.icon {
 	.col-icon {
 		max-width:26px !important;
 	}
+	.col-data {
+		width: calc(100% - 30px);
+	}
+
+	.trashcan {
+		height: 25px !important;
+	}
+
 }
 
 .modal-dialog {

--- a/js/main.js
+++ b/js/main.js
@@ -807,7 +807,7 @@ function loadFrame(f, frame) {
     var width = 12;
     if (typeof(frame.width) !== 'undefined') width = frame.width;
     var html = '<div data-id="frames.' + key + '" class="col-xs-' + width + ' hover transbg swiper-no-swiping imgblock imgblock' + f + '" style="height:' + frame.height + 'px;padding:0px !important;">';
-    html += '<div class="col-xs-12 col-data" style="padding:0px !important;">';
+    html += '<div class="col-xs-12 col-no-icon" style="padding:0px !important;">';
     html += '<iframe src="' + frame.frameurl + '" style="width:100%;border:0px;height:' + (frame.height - 14) + 'px;"></iframe>';
     html += '</div>';
     html += '</div>';
@@ -1565,7 +1565,7 @@ function handleDevice(device, idx) {
             html += '</div>';
         }
         else {
-            html += '<div class="col-xs-8 col-data" style="width: calc(100% - 50px);">';
+            html += '<div class="col-xs-8 col-data">';
             html += '<strong class="title">' + device['Name'] + '</strong><br />';
             html += '<div class="btn-group" data-toggle="buttons">';
             for (a in names) {
@@ -2088,7 +2088,7 @@ function getDimmerBlock(device, idx, buttonimg) {
     }
     this.html += '</strong>';
     if (showUpdateInformation(idx)) {
-        this.html += ' / <span class="lastupdate">' + moment(device['LastUpdate']).format(settings['timeformat']) + '</span>';
+        this.html += ' &nbsp; <span class="lastupdate">' + moment(device['LastUpdate']).format(settings['timeformat']) + '</span>';
     }
     this.html += '<br />';
     if (isRGBDeviceAndEnabled(device)) {

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 {
-"version": "2.3.10",
+"version": "2.3.11",
 "branch": "beta",
-"last_changes": "Added security switch",
+"last_changes": "Improved column widths",
 "changelog" : {
+            "2.3.10": "Added security switch", 
             "2.3.9": "Additional fix for older browsers breaking on const keyword",
             "2.3.8": "Fix scene switching, fix for older browsers breaking on const keyword",
             "2.3.7": "Fix voor redirect in Kiosk Browser",


### PR DESCRIPTION
The grid system is not ideal for the blocks itself, because the content is more or less fixed. This gave issues for the slider-devices.

I've made the icon part fixed width. The remainder of the column will get the remaining width.

I've added one class in creative.css (col-no-icon) for full width blocks without icon.

I've tried to get side effects as minimal as possible, but please test at your system as well, preferably with different screen sizes. 
