### PR TITLE
fix OWM save settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -261,6 +261,22 @@ settingList['weather']['wu_country'] = {};
 settingList['weather']['wu_country']['title'] = language.settings.weather.wu_country;
 settingList['weather']['wu_country']['type'] = 'text';
 
+settingList['weather']['owm_api'] = {};
+settingList['weather']['owm_api']['title'] = language.settings.weather.owm_api;
+settingList['weather']['owm_api']['type'] = 'text';
+
+settingList['weather']['owm_city'] = {};
+settingList['weather']['owm_city']['title'] = language.settings.weather.owm_city;
+settingList['weather']['owm_city']['type'] = 'text';
+
+settingList['weather']['owm_name'] = {};
+settingList['weather']['owm_name']['title'] = language.settings.weather.owm_name;
+settingList['weather']['owm_name']['type'] = 'text';
+
+settingList['weather']['owm_country'] = {};
+settingList['weather']['owm_country']['title'] = language.settings.weather.owm_country;
+settingList['weather']['owm_country']['type'] = 'text';
+
 settingList['weather']['idx_moonpicture'] = {};
 settingList['weather']['idx_moonpicture']['title'] = language.settings.weather.idx_moonpicture;
 settingList['weather']['idx_moonpicture']['type'] = 'text';

--- a/lang/bs_BA.json
+++ b/lang/bs_BA.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API ključ",
             "wu_city": "Wunderground stanica (grad ili poštanski broj)",
             "wu_country": "Država za Wunderground",
-            "wu_name": "Prikaži naziv"
+            "wu_name": "Prikaži naziv",
+            "owm_api": "OWM API ključ",
+            "owm_city": "OWM stanica (grad ili poštanski broj)",
+            "owm_country": "Država za OWM",
+            "owm_name": "OWM Prikaži naziv"
         }
     },
     "switches": {

--- a/lang/ca_ES.json
+++ b/lang/ca_ES.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Display Name"
+            "wu_name": "Display Name",
+            "owm_api": "OWM API Key",
+            "owm_city": "OWM Station (City or Code)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Display Name"
         }
     },
     "switches": {

--- a/lang/cs_CZ.json
+++ b/lang/cs_CZ.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Zobrazované jméno"
+            "wu_name": "Zobrazované jméno",
+            "owm_api": "OWM API Key",
+            "owm_city": "OWM Station (City or Code)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Zobrazované jméno"
         }
     },
     "switches": {

--- a/lang/da_DK.json
+++ b/lang/da_DK.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Nøgle",
             "wu_city": "Wunderground Station (by eller kode)",
             "wu_country": "Wunderground land",
-            "wu_name": "Visningsnavn"
+            "wu_name": "Visningsnavn",
+            "owm_api": "OWM API-Nøgle",
+            "owm_city": "OWM Station (by eller kode)",
+            "owm_country": "OWM land",
+            "owm_name": "OWM Visningsnavn"
         }
     },
     "switches": {

--- a/lang/de_DE.json
+++ b/lang/de_DE.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Schlüssel",
             "wu_city": "Wunderground Messstation (Stadt oder Code)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Anzeigename"
+            "wu_name": "Anzeigename",
+            "owm_api": "OWM API-Schlüssel",
+            "owm_city": "OWM Messstation (Stadt oder Code)",
+            "owm_country": "OWM Land",
+            "owm_name": "OWM Anzeigename"
         }
     },
     "switches": {

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Display Name"
+            "wu_name": "Display Name",
+            "owm_api": "OWM API Key",
+            "owm_city": "OWM Station (City or Code)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Display Name"
         }
     },
     "switches": {

--- a/lang/es_ES.json
+++ b/lang/es_ES.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground Clave de API",
             "wu_city": "Wunderground de la Estación (Ciudad o Código)",
             "wu_country": "Wunderground País",
-            "wu_name": "Nombre para mostrar"
+            "wu_name": "Nombre para mostrar",
+            "owm_api": "OWM Clave de API",
+            "owm_city": "OWM de la Estación (Ciudad o Código)",
+            "owm_country": "OWM País",
+            "owm_name": "OWM Nombre para mostrar"
         }
     },
     "switches": {

--- a/lang/fi_FI.json
+++ b/lang/fi_FI.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Avain",
             "wu_city": "Wunderground asema (kaupunki tai koodi)",
             "wu_country": "Wunderground Maa",
-            "wu_name": "Näyttönimi"
+            "wu_name": "Näyttönimi",
+            "owm_api": "OWM API-Avain",
+            "owm_city": "OWM asema (kaupunki tai koodi)",
+            "owm_country": "OWM Maa",
+            "owm_name": "OWM Näyttönimi"
         }
     },
     "switches": {

--- a/lang/fr_FR.json
+++ b/lang/fr_FR.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (Ville ou Code)",
             "wu_country": "Wunderground Pays",
-            "wu_name": "Nom D'Affichage"
+            "wu_name": "Nom D'Affichage",
+            "owm_api": "OWM API Key",
+            "owm_city": "OWM Station (Ville ou Code)",
+            "owm_country": "OWM Pays",
+            "owm_name": "OWM Nom D'Affichage"
         }
     },
     "switches": {

--- a/lang/hu_HU.json
+++ b/lang/hu_HU.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Kulcs",
             "wu_city": "Wunderállomás (város vagy kód)",
             "wu_country": "Wunderground Ország",
-            "wu_name": "Megjelenítendő név"
+            "wu_name": "Megjelenítendő név",
+            "owm_api": "OWM API Kulcs",
+            "owm_city": "OWM állomás (város vagy kód)",
+            "owm_country": "OWM Ország",
+            "owm_name": "OWM Megjelenítendő név"
         }
     },
     "switches": {

--- a/lang/it_IT.json
+++ b/lang/it_IT.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Stazione Wunderground (Città o Codice)",
             "wu_country": "Paese Wunderground",
-            "wu_name": "Nome da visualizzare"
+            "wu_name": "Nome da visualizzare",
+            "owm_api": "OWM API Key",
+            "owm_city": "Stazione OWM Station (Città o Codice)",
+            "owm_country": "Paese OWM",
+            "owm_name": "OWM Nome da visualizzare"
         }
     },
     "switches": {

--- a/lang/nl_NL.json
+++ b/lang/nl_NL.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Sleutel",
             "wu_city": "Wunderground Station (Stad of Code)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Weergavenaam"
+            "wu_name": "Weergavenaam",
+            "owm_api": "OWM API-Sleutel",
+            "owm_city": "OWM Station (Stad of Code)",
+            "owm_country": "OWM Land",
+            "owm_name": "OWM Weergavenaam"
         }
     },
     "switches": {

--- a/lang/nn_NO.json
+++ b/lang/nn_NO.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Nøkkel",
             "wu_city": "Wunderground Station (Byen eller Kode)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Visningsnavn"
+            "wu_name": "Visningsnavn",
+            "owm_api": "OWM API-Nøkkel",
+            "owm_city": "OWM Station (Byen eller Kode)",
+            "owm_country": "OWM Land",
+            "owm_name": "OWM Visningsnavn"
         }
     },
     "switches": {

--- a/lang/pl_PL.json
+++ b/lang/pl_PL.json
@@ -178,7 +178,11 @@
             "wu_api": "Klucz API programu Wunderground",
             "wu_city": "Stacja Wunderground (miasto lub kod)",
             "wu_country": "Kraj Wunderground",
-            "wu_name": "Wyświetlana nazwa"
+            "wu_name": "Wyświetlana nazwa",
+            "owm_api": "Klucz API programu OWM",
+            "owm_city": "Stacja OWM (miasto lub kod)",
+            "owm_country": "Kraj OWM",
+            "owm_name": "Wyświetlana nazwa OWM"
         }
     },
     "switches": {

--- a/lang/pt_PT.json
+++ b/lang/pt_PT.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Estação Wunderground (Cidade ou Código)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Mostrar nome"
+            "wu_name": "Mostrar nome",
+            "owm_api": "OWM API Key",
+            "owm_city": "Estação OWM (Cidade ou Código)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Mostrar nome"
         }
     },
     "switches": {

--- a/lang/ru_RU.json
+++ b/lang/ru_RU.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-ключ",
             "wu_city": "Wunderground станция (город или код)",
             "wu_country": "Wunderground страна",
-            "wu_name": "Отображаемое имя"
+            "wu_name": "Отображаемое имя",
+            "owm_api": "OWM API-ключ",
+            "owm_city": "OWM станция (город или код)",
+            "owm_country": "OWM страна",
+            "owm_name": "OWM Отображаемое имя"
         }
     },
     "switches": {

--- a/lang/sk_SK.json
+++ b/lang/sk_SK.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Kľúč",
             "wu_city": "Stanica Wunderground (mesto alebo kód)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Zobraziť meno"
+            "wu_name": "Zobraziť meno",
+            "owm_api": "OWM API Kľúč",
+            "owm_city": "Stanica OWM (mesto alebo kód)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Zobraziť meno"
         }
     },
     "switches": {

--- a/lang/sl_SI.json
+++ b/lang/sl_SI.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Ključ",
             "wu_city": "Wunderground Postaje (Mesto ali Kodo)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Prikazno ime"
+            "wu_name": "Prikazno ime",
+            "owm_api": "OWM API Ključ",
+            "owm_city": "OWM Postaje (Mesto ali Kodo)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Prikazno ime"
         }
     },
     "switches": {

--- a/lang/sr_RS.json
+++ b/lang/sr_RS.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Ključ",
             "wu_city": "Wunderground stanica (Grad ili kod)",
             "wu_country": "Wunderground Država",
-            "wu_name": "Ime za prikaz"
+            "wu_name": "Ime za prikaz",
+            "owm_api": "OWM API Ključ",
+            "owm_city": "OWM stanica (Grad ili kod)",
+            "owm_country": "OWM Država",
+            "owm_name": "OWM Ime za prikaz"
         }
     },
     "switches": {

--- a/lang/sv_SE.json
+++ b/lang/sv_SE.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Nyckel",
             "wu_city": "Wunderground Station (Ort eller kod)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Visningsnamn"
+            "wu_name": "Visningsnamn",
+            "owm_api": "OWM API Nyckel",
+            "owm_city": "OWM Station (Ort eller kod)",
+            "owm_country": "OWM Land",
+            "owm_name": "OWM Visningsnamn"
         }
     },
     "switches": {

--- a/lang/tr_TR.json
+++ b/lang/tr_TR.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Anahtarı",
             "wu_city": "Wunderground İstasyonu (Şehir veya Kod)",
             "wu_country": "Wunderground Ülke",
-            "wu_name": "Görüntü Adı"
+            "wu_name": "Görüntü Adı",
+            "owm_api": "OWM API Anahtarı",
+            "owm_city": "OWM İstasyonu (Şehir veya Kod)",
+            "owm_country": "OWM Ülke",
+            "owm_name": "OWM Görüntü Adı"
         }
     },
     "switches": {

--- a/lang/uk_UA.json
+++ b/lang/uk_UA.json
@@ -178,7 +178,11 @@
             "wu_api": "Ключ під ключ під ключ",
             "wu_city": "Станція підземелля (місто або код)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Відображуване ім'я"
+            "wu_name": "Відображуване ім'я",
+            "owm_api": "OWM Ключ під ключ під ключ",
+            "owm_city": "OWM Станція підземелля (місто або код)",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM Відображуване ім'я"
         }
     },
     "switches": {

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API密钥",
             "wu_city": "Wunderground站（城市或代码）",
             "wu_country": "Wunderground Country",
-            "wu_name": "显示名称"
+            "wu_name": "显示名称",
+            "owm_api": "OWM API密钥",
+            "owm_city": "OWM站（城市或代码）",
+            "owm_country": "OWM Country",
+            "owm_name": "OWM 显示名称"
         }
     },
     "switches": {

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 {
-"version": "2.3.11",
+"version": "2.3.12",
 "branch": "beta",
-"last_changes": "Fix to read version when update check is disabled, Added 'Disabled update check' to settings tab.",
+"last_changes": "Fix for save OWM settings",
 "changelog" : {
+            "2.3.11": "Fix to read version when update check is disabled, Added 'Disabled update check' to settings tab.",
             "2.3.10": "Added security switch", 
             "2.3.9": "Additional fix for older browsers breaking on const keyword",
             "2.3.8": "Fix scene switching, fix for older browsers breaking on const keyword",


### PR DESCRIPTION
With #350 OpenWeatherMap was added. This PR enables modifying and saving the OWM settings via the Dashticz setting page.
