### PR TITLE
OWM Parameters stored via web browser + translation

### DIFF
--- a/js/garbage.js
+++ b/js/garbage.js
@@ -8,7 +8,7 @@ function loadGarbage() {
     if (typeof(settings['garbage_hideicon']) !== 'undefined' && parseFloat(settings['garbage_hideicon']) === 1) {
         html += '<div class="col-xs-12 col-data">';
     } else {
-        html += '<div class="col-xs-4 col-icon">';
+        html += '<div class="col-xs-4 col-icon-trash">';
         html += '<img class="trashcan" src="img/garbage/kliko.png" style="opacity:0.1" />';
         html += '</div>';
         html += '<div class="col-xs-8 col-data">';
@@ -384,7 +384,7 @@ function getEdgData(address, date, random) {
 
 function getTrashRow(garbage) {
     this.rowClass = 'trashrow';
-    this.displayDate = garbage.date.locale(settings['calendarlanguage']).format('l');
+    this.displayDate = garbage.date.locale(settings['calendarlanguage']).format(settings['calendarformat']);
     if (garbage.date.isSame(moment(), 'day')) {
         this.displayDate = language.weekdays.today;
         this.rowClass = 'trashtoday';

--- a/js/settings.js
+++ b/js/settings.js
@@ -261,6 +261,22 @@ settingList['weather']['wu_country'] = {};
 settingList['weather']['wu_country']['title'] = language.settings.weather.wu_country;
 settingList['weather']['wu_country']['type'] = 'text';
 
+settingList['weather']['owm_api'] = {};
+settingList['weather']['owm_api']['title'] = language.settings.weather.owm_api;
+settingList['weather']['owm_api']['type'] = 'text';
+
+settingList['weather']['owm_city'] = {};
+settingList['weather']['owm_city']['title'] = language.settings.weather.owm_city;
+settingList['weather']['owm_city']['type'] = 'text';
+
+settingList['weather']['owm_name'] = {};
+settingList['weather']['owm_name']['title'] = language.settings.weather.owm_name;
+settingList['weather']['owm_name']['type'] = 'text';
+
+settingList['weather']['owm_country'] = {};
+settingList['weather']['owm_country']['title'] = language.settings.weather.owm_country;
+settingList['weather']['owm_country']['type'] = 'text';
+
 settingList['weather']['idx_moonpicture'] = {};
 settingList['weather']['idx_moonpicture']['title'] = language.settings.weather.idx_moonpicture;
 settingList['weather']['idx_moonpicture']['type'] = 'text';

--- a/lang/bs_BA.json
+++ b/lang/bs_BA.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API ključ",
             "wu_city": "Wunderground stanica (grad ili poštanski broj)",
             "wu_country": "Država za Wunderground",
-            "wu_name": "Prikaži naziv"
+            "wu_name": "Prikaži naziv",
+            "owm_api": "Open Weather Map API ključ",
+            "owm_city": "Open Weather Map stanica (grad ili poštanski broj)",
+            "owm_country": "Država za Open Weather Map",
+            "owm_name": "Prikaži naziv Open Weather Map"
         }
     },
     "switches": {

--- a/lang/ca_ES.json
+++ b/lang/ca_ES.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Display Name"
+            "wu_name": "Display Name",
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Open Weather Map Station (City or Code)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Display Name Open Weather Map"
         }
     },
     "switches": {

--- a/lang/cs_CZ.json
+++ b/lang/cs_CZ.json
@@ -179,6 +179,10 @@
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
             "wu_name": "Zobrazované jméno"
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Open Weather Map Station (City or Code)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Zobrazované jméno Open Weather Map"
         }
     },
     "switches": {

--- a/lang/da_DK.json
+++ b/lang/da_DK.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Nøgle",
             "wu_city": "Wunderground Station (by eller kode)",
             "wu_country": "Wunderground land",
-            "wu_name": "Visningsnavn"
+            "wu_name": "Visningsnavn",
+            "owm_api": "Open Weather Map API-Nøgle",
+            "owm_city": "Open Weather Map Station (by eller kode)",
+            "owm_country": "Open Weather Map land",
+            "owm_name": "Visningsnavn Open Weather Map"
         }
     },
     "switches": {

--- a/lang/de_DE.json
+++ b/lang/de_DE.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Schlüssel",
             "wu_city": "Wunderground Messstation (Stadt oder Code)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Anzeigename"
+            "wu_name": "Anzeigename",
+            "owm_api": "Open Weather Map API-Schlüssel",
+            "owm_city": "Open Weather Map Messstation (Stadt oder Code)",
+            "owm_country": "Open Weather Map Land",
+            "owm_name": "Anzeigename Open Weather Map"
         }
     },
     "switches": {

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (City or Code)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Display Name"
+            "wu_name": "Display Name",
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Open Weather Map Station (City or Code)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Display Name Open Weather Map"
         }
     },
     "switches": {

--- a/lang/es_ES.json
+++ b/lang/es_ES.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground Clave de API",
             "wu_city": "Wunderground de la Estación (Ciudad o Código)",
             "wu_country": "Wunderground País",
-            "wu_name": "Nombre para mostrar"
+            "wu_name": "Nombre para mostrar",
+            "owm_api": "Open Weather Map Clave de API",
+            "owm_city": "Open Weather Map de la Estación (Ciudad o Código)",
+            "owm_country": "Open Weather Map País",
+            "owm_name": "Nombre para mostrar Open Weather Map"
         }
     },
     "switches": {

--- a/lang/fi_FI.json
+++ b/lang/fi_FI.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Avain",
             "wu_city": "Wunderground asema (kaupunki tai koodi)",
             "wu_country": "Wunderground Maa",
-            "wu_name": "Näyttönimi"
+            "wu_name": "Näyttönimi",
+            "owm_api": "Open Weather Map API-Avain",
+            "owm_city": "Open Weather Map asema (kaupunki tai koodi)",
+            "owm_country": "Open Weather Map Maa",
+            "owm_name": "Näyttönimi Open Weather Map"
         }
     },
     "switches": {

--- a/lang/fr_FR.json
+++ b/lang/fr_FR.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Wunderground Station (Ville ou Code)",
             "wu_country": "Wunderground Pays",
-            "wu_name": "Nom D'Affichage"
+            "wu_name": "Nom D'Affichage",
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Open Weather Map Station (Ville ou Code)",
+            "owm_country": "Open Weather Map Pays",
+            "owm_name": "Nom D'Affichage Open Weather Map"
         }
     },
     "switches": {

--- a/lang/hu_HU.json
+++ b/lang/hu_HU.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Kulcs",
             "wu_city": "Wunderállomás (város vagy kód)",
             "wu_country": "Wunderground Ország",
-            "wu_name": "Megjelenítendő név"
+            "wu_name": "Megjelenítendő név",
+            "owm_api": "Open Weather Map API Kulcs",
+            "owm_city": "Open Weather Map (város vagy kód)",
+            "owm_country": "Open Weather Map Ország",
+            "owm_name": "Megjelenítendő név Open Weather Map"
         }
     },
     "switches": {

--- a/lang/it_IT.json
+++ b/lang/it_IT.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Stazione Wunderground (Città o Codice)",
             "wu_country": "Paese Wunderground",
-            "wu_name": "Nome da visualizzare"
+            "wu_name": "Nome da visualizzare",
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Stazione Open Weather Map (Città o Codice)",
+            "owm_country": "Paese Open Weather Map",
+            "owm_name": "Nome da visualizzare Open Weather Map"
         }
     },
     "switches": {

--- a/lang/nl_NL.json
+++ b/lang/nl_NL.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Sleutel",
             "wu_city": "Wunderground Station (Stad of Code)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Weergavenaam"
+            "wu_name": "Weergavenaam",
+            "owm_api": "Open Weather Map API-Sleutel",
+            "owm_city": "Open Weather Map Station (Stad of Code)",
+            "owm_country": "Open Weather Map Land",
+            "owm_name": "Weergavenaam Open Weather Map"
         }
     },
     "switches": {

--- a/lang/nn_NO.json
+++ b/lang/nn_NO.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-Nøkkel",
             "wu_city": "Wunderground Station (Byen eller Kode)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Visningsnavn"
+            "wu_name": "Visningsnavn",
+            "owm_api": "Open Weather Map API-Nøkkel",
+            "owm_city": "Open Weather Map Station (Byen eller Kode)",
+            "owm_country": "Open Weather Map Land",
+            "owm_name": "Visningsnavn Open Weather Map"
         }
     },
     "switches": {

--- a/lang/pl_PL.json
+++ b/lang/pl_PL.json
@@ -178,7 +178,11 @@
             "wu_api": "Klucz API programu Wunderground",
             "wu_city": "Stacja Wunderground (miasto lub kod)",
             "wu_country": "Kraj Wunderground",
-            "wu_name": "Wyświetlana nazwa"
+            "wu_name": "Wyświetlana nazwa",
+            "owm_api": "Klucz API programu Open Weather Map",
+            "owm_city": "Stacja Open Weather Map (miasto lub kod)",
+            "owm_country": "Kraj Open Weather Map",
+            "owm_name": "Wyświetlana nazwa Open Weather Map" 
         }
     },
     "switches": {

--- a/lang/pt_PT.json
+++ b/lang/pt_PT.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Key",
             "wu_city": "Estação Wunderground (Cidade ou Código)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Mostrar nome"
+            "wu_name": "Mostrar nome",
+            "owm_api": "Open Weather Map API Key",
+            "owm_city": "Estação Open Weather Map (Cidade ou Código)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Mostrar nome Open Weather Map"
         }
     },
     "switches": {

--- a/lang/ru_RU.json
+++ b/lang/ru_RU.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API-ключ",
             "wu_city": "Wunderground станция (город или код)",
             "wu_country": "Wunderground страна",
-            "wu_name": "Отображаемое имя"
+            "wu_name": "Отображаемое имя",
+            "owm_api": "Open Weather Map API-ключ",
+            "owm_city": "Open Weather Map станция (город или код)",
+            "owm_country": "Open Weather Map страна",
+            "owm_name": "Отображаемое имя Open Weather Map"
         }
     },
     "switches": {

--- a/lang/sk_SK.json
+++ b/lang/sk_SK.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Kľúč",
             "wu_city": "Stanica Wunderground (mesto alebo kód)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Zobraziť meno"
+            "wu_name": "Zobraziť meno",
+            "owm_api": "Open Weather Map API Kľúč",
+            "owm_city": "Stanica Open Weather Map (mesto alebo kód)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Zobraziť meno Open Weather Map"
         }
     },
     "switches": {

--- a/lang/sl_SI.json
+++ b/lang/sl_SI.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Ključ",
             "wu_city": "Wunderground Postaje (Mesto ali Kodo)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Prikazno ime"
+            "wu_name": "Prikazno ime",
+            "owm_api": "Open Weather Map API Ključ",
+            "owm_city": "Open Weather Map Postaje (Mesto ali Kodo)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Prikazno ime Open Weather Map"
         }
     },
     "switches": {

--- a/lang/sr_RS.json
+++ b/lang/sr_RS.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Ključ",
             "wu_city": "Wunderground stanica (Grad ili kod)",
             "wu_country": "Wunderground Država",
-            "wu_name": "Ime za prikaz"
+            "wu_name": "Ime za prikaz",
+            "owm_api": "Open Weather Map API Ključ",
+            "owm_city": "Open Weather Map stanica (Grad ili kod)",
+            "owm_country": "Open Weather Map Država",
+            "owm_name": "Ime za prikaz Open Weather Map"
         }
     },
     "switches": {

--- a/lang/sv_SE.json
+++ b/lang/sv_SE.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Nyckel",
             "wu_city": "Wunderground Station (Ort eller kod)",
             "wu_country": "Wunderground Land",
-            "wu_name": "Visningsnamn"
+            "wu_name": "Visningsnamn",
+            "owm_api": "Open Weather Map API Nyckel",
+            "owm_city": "Open Weather Map Station (Ort eller kod)",
+            "owm_country": "Open Weather Map Land",
+            "owm_name": "Visningsnamn Open Weather Map"
         }
     },
     "switches": {

--- a/lang/tr_TR.json
+++ b/lang/tr_TR.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API Anahtarı",
             "wu_city": "Wunderground İstasyonu (Şehir veya Kod)",
             "wu_country": "Wunderground Ülke",
-            "wu_name": "Görüntü Adı"
+            "wu_name": "Görüntü Adı",
+            "owm_api": "Open Weather Map API Anahtarı",
+            "owm_city": "Open Weather Map İstasyonu (Şehir veya Kod)",
+            "owm_country": "Open Weather Map Ülke",
+            "owm_name": "Görüntü Adı Open Weather Map"
         }
     },
     "switches": {

--- a/lang/uk_UA.json
+++ b/lang/uk_UA.json
@@ -178,7 +178,11 @@
             "wu_api": "Ключ під ключ під ключ",
             "wu_city": "Станція підземелля (місто або код)",
             "wu_country": "Wunderground Country",
-            "wu_name": "Відображуване ім'я"
+            "wu_name": "Відображуване ім'я",
+            "owm_api": "Open Weather Map Ключ під ключ під ключ",
+            "owm_city": "Open Weather Map Станція підземелля (місто або код)",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "Відображуване ім'я Open Weather Map"
         }
     },
     "switches": {

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -178,7 +178,11 @@
             "wu_api": "Wunderground API密钥",
             "wu_city": "Wunderground站（城市或代码）",
             "wu_country": "Wunderground Country",
-            "wu_name": "显示名称"
+            "wu_name": "显示名称",
+            "owm_api": "Open Weather Map API密钥",
+            "owm_city": "Open Weather Map 站（城市或代码）",
+            "owm_country": "Open Weather Map Country",
+            "owm_name": "显示名称 Open Weather Map"
         }
     },
     "switches": {


### PR DESCRIPTION
Hi, 

According to: https://github.com/Dashticz/dashticz_v2/pull/350

@lokonli has mentioned:

> Further, can you also add an entry in the settinglist for all the owm related settings (See line 244 and further in settings.js for the wu examples). Otherwise we can't save the settings correctly from the dashticz webpage.
> 
> Last, can you extend all the language files with the OWM language identifiers you've added?

So I have done it. :)

Best regards,

Adrian