### PR TITLE
Accelerate first loading of public transport info.

### DIFF
--- a/js/publictransport.js
+++ b/js/publictransport.js
@@ -26,8 +26,10 @@ function loadPublicTransport(random,transportobject,key){
 	//Get data every interval and call function to create block
 	var interval = 60;
 	if(typeof(transportobject.interval)!=='undefined') interval = transportobject.interval;
-	getData(random,transportobject);
-	setTimeout(function(){$('.publictransport'+random+' .state').html(language.misc.loading);},100);
+	setTimeout(function(){
+		$('.publictransport'+random+' .state').html(language.misc.loading);
+		getData(random,transportobject);
+	},100);
 	
 	if(transportobject.provider.toLowerCase() == 'ns'){
 		if(parseFloat(interval)<60) interval=60; // limit request because of limitations in NS api for my private key ;)


### PR DESCRIPTION
THe initial loading of the public transport info failed because the
transportobject had not been updated yet. This is solved by waiting
100ms before updating the data.