### PR TITLE
Fix garbage name mapping

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -463,9 +463,6 @@ settingList['about']['about_text3']['title'] = 'Do you appreciate my work and wa
 settingList['about']['about_text4'] = {};
 settingList['about']['about_text4']['title'] = 'If you have any issues you can report them in our community thread <a href="https://www.domoticz.com/forum/viewtopic.php?f=67&t=17427" target="_blank">Bug report</a>.'
 
-settingList['about']['about_text5'] = {};
-settingList['about']['about_text5']['title'] = domoversion + dzVents + python;
-
 var settings = {};
 doneSettings = false;
 if (typeof(Storage) !== "undefined") {
@@ -593,6 +590,22 @@ for (var s in settingList){
 
 var _TEMP_SYMBOL = '°C';
 if (settings['use_fahrenheit'] === 1) _TEMP_SYMBOL = '°F';
+
+var phpversion = '<br>PHP not installed!!';
+
+$.ajax({
+    url: settings['dashticz_php_path']+'info.php?get=phpversion',
+    async: false,
+    dataType: 'json',
+    success: function (data) {
+        phpversion = '<br> PHP version: ' + data;
+                }
+});
+
+settingList['about']['about_text5'] = {};
+settingList['about']['about_text5']['title'] = domoversion + dzVents + python + phpversion;
+
+
 
 function loadSettings() {
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -555,9 +555,9 @@ if (typeof(settings['garbage']) === 'undefined') {
 }
 if (typeof(settings['garbage_mapping']) === 'undefined') {
     settings['garbage_mapping'] = {
+        rest: ['grof', 'grey', 'rest', 'grijs','grijze'],
         gft: ['gft', 'tuin', 'refuse bin', 'green', 'groen', 'Biodégradables', 'snoei'],
         pmd: ['plastic', 'pmd', 'verpakking', 'kunststof', 'valorlux'],
-        rest: ['grof', 'grey', 'rest', 'grijs','grijze'],
         papier: ['papier', 'blauw', 'blue', 'recycling bin collection'],
         kca: ['chemisch', 'kca','kga'],
         brown: ['brown', 'verre'],

--- a/vendor/dashticz/garbage/index.php
+++ b/vendor/dashticz/garbage/index.php
@@ -1,4 +1,6 @@
 <?php
+header("Access-Control-Allow-Origin: *");
+header('Content-Type: application/json');
 $allDates=array();
 switch($_GET['service']){
 	case 'rova':

--- a/vendor/dashticz/ical/index.php
+++ b/vendor/dashticz/ical/index.php
@@ -1,4 +1,6 @@
 <?php
+header("Access-Control-Allow-Origin: *");
+header('Content-Type: application/json');
 require_once('SG_iCal.php');
 $ICS = $_GET['url'];
 $ICS = str_replace('#','%23',urldecode($ICS));

--- a/vendor/dashticz/info.php
+++ b/vendor/dashticz/info.php
@@ -1,0 +1,14 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header('Content-Type: application/json');
+$allDates=array();
+switch($_GET['get']){
+  case 'phpversion':
+    $return=phpversion();
+    break;
+}
+die(json_encode($return));
+echo '<pre>';
+print_r($return);
+exit();
+?>

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 {
-"version": "2.4.5",
+"version": "2.4.6",
 "branch": "beta",
-"last_changes": "Fix for cross origin issues with php",
+"last_changes": "Small change in garbage name mapping rules to support Dordrecht",
 "changelog" : {
+            "2.4.5": "Fix for cross origin issues with php",
             "2.4.4": "Fix HVC garbage data",
             "2.4.3": "Use local garbage.php module",
             "2.4.2": "Merge PHP OV Module into Dashticz",

--- a/version.txt
+++ b/version.txt
@@ -1,8 +1,9 @@
 {
-"version": "2.4.4",
+"version": "2.4.5",
 "branch": "beta",
-"last_changes": "Fix HVC garbage data",
+"last_changes": "Fix for cross origin issues with php",
 "changelog" : {
+            "2.4.4": "Fix HVC garbage data",
             "2.4.3": "Use local garbage.php module",
             "2.4.2": "Merge PHP OV Module into Dashticz",
             "2.4.1": "Merge PHP TV Module into Dashticz",


### PR DESCRIPTION
Small fix in the garbage name mapping, especially for Dordrecht.
Dordrecht returns "Gft & etensresten" as garbage type. Because this contains the part 'rest' is was mapped to rest afval.

By changing the order of lines in the garbage mapping tables I've corrected this with probably no impact for other users. Since 'Gft' is also in the name, and the name mapping rule for gft comes after the name mapping rule of rest it now will be correctly mapped to gft.
