### PR TITLE
Fix domoticz.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before you can use this dashboard, unzip all files to a subfolder in Domoticz or
 Save CONFIG_DEFAULT.js as CONFIG.js and insert the IP-address of Domoticz without a trailing slash; e.g.: http://192.168.1.3:8084
 
 
-Visit the wikipage at: http://www.domoticz.com/wiki/Dashticz_V2
+Visit the wikipage at: https://www.domoticz.com/wiki/Dashticz_V2
 
 # Run in Docker
 Navigate the directory to be in the same level as the Dockerfile and run this command
@@ -50,11 +50,11 @@ You'll have to re-install Dashticz in that case.
 
 ### Where can I get any help?
 You can check out our helpful community in the [Dashticz subforum](https://www.domoticz.com/forum/viewforum.php?f=67) on the Domoticz forum. Various topics on the various parts of Dashticz can give you lots of help and examples on configuration. Feel free to ask you question.
-See also the [Wiki](http://www.domoticz.com/wiki/Dashticz_V2) for the various options in dashticz.
+See also the [Wiki](https://www.domoticz.com/wiki/Dashticz_V2) for the various options in dashticz.
 
 ### Contribute to Dashticz
 If you want to contribute to Dashticz: Just create a pull request with you bugfix, addition, typofix or something else you think is valuable. If you have no idea of what to fix: Look at the issues on Github, or visit the [Dashticz subforum](https://www.domoticz.com/forum/viewforum.php?f=67) where users describing bugs or requesting features can be found.
 
-Improving the [Wiki](http://www.domoticz.com/wiki/Dashticz_V2) is also a good way to contribute.
+Improving the [Wiki](https://www.domoticz.com/wiki/Dashticz_V2) is also a good way to contribute.
 
 Thanks for your help!


### PR DESCRIPTION
Update http://www.domoticz.com links to https://www.domoticz.com as the current ones give 404s